### PR TITLE
added livelossplot python package

### DIFF
--- a/_data/works.yml
+++ b/_data/works.yml
@@ -1441,3 +1441,35 @@
       after: x
   where:
     - venue: TVCG
+    
+- paper: migdal2019livelossplot
+  url: https://github.com/stared/livelossplot
+  author: Migdał, et al.
+  year: 2019
+  why:
+    - interpretability: o
+      debugging: x
+      comparing: o
+      education: x
+  who: 
+    - model-developers: x
+      model-users: o
+      non-experts: o
+  what:
+    - graph: o
+      learned: o
+      units: o
+      neurons: o
+      aggregated: x
+  how: 
+    - node-link: o
+      scatter: o
+      line: x
+      instance-based: x
+      interactive-experimentation: o
+      algorithms: o
+  when:
+    - during: x
+      after: o
+  where:
+    - venue: GitHub


### PR DESCRIPTION
Hi @fredhohman!

I add https://github.com/stared/livelossplot, an Python package for visualizing metrics during training. It is extensible, so one can add other qualities to track during training (e.g. https://github.com/stared/livelossplot/blob/master/examples/2d_prediction_maps.ipynb for didactic purposes)
.
Not sure how you approach packages (rather than publications). Though, since there are some things with "publication: web" I give it a try (especially many machine learning visualization tools are primarily/only libraries). 

As a side note, I like this PR-based lists, vide http://p.migdal.pl/interactive-machine-learning-list/.